### PR TITLE
A bunch of things actually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "crcracker"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "cloudflare-zlib-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crcracker"
 description = "obliterate xiv shader hashes"
 authors = ["NotNite <hi@notnite.com>"]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ XIV shaders store hashed names, usually in the format of `g_{word one}{word two}
 it's speedy, because
 
 - it's in :rocket: :crab: rust :crab: :rocket:
-- it's multi-threaded (albeit poorly)
-- it uses CRC Combination (sparkles)
+- it's multi-threaded :twisted_rightwards_arrows: (albeit poorly)
+- it uses CRC Combination :sparkles:
+- it uses some kind of meet-in-the-middle attack :comet:
 
 ## usage
 
@@ -28,10 +29,13 @@ by default, hashes will be printed both immediately when found and when all poss
 
 ## arguments
 
-- `-w, --word-list`: path to word list file
-- `-h, --hash-list`: path to hash list file
+- `-W, --word-list`: path to word list file
+- `-H, --hash-list`: path to hash list file
 - `-t, --threads`: number of threads to use (default: 1, *incredibly* slow)
 - `-p, --prefix`: prefix to use for hashing (optional)
+- `-P, --prefix-hash`: hash of an unknown prefix to use for partial attacks (optional)
+- `-s, --separator`: separator to use between words for hashing (optional)
+- `-x, --suffix`: suffix to use for hashing (optional)
 - `--print-when-found`: whether to print immediately when a hash is found (default: true)
 
 ## collisions

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,39 @@
 use clap::Parser;
-use cloudflare_zlib_sys::crc32;
-use cloudflare_zlib_sys::crc32_combine;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+mod xivcrc32;
+
+use xivcrc32::XivCrc32;
+
 #[derive(Parser, Clone)]
 struct Args {
-    #[clap(short, long)]
+    #[clap(short = 'W', long)]
     word_list: PathBuf,
 
-    #[clap(short, long)]
+    #[clap(short = 'H', long)]
     hash_list: PathBuf,
 
-    #[clap(short, long, default_value = "1")]
+    #[clap(short = 't', long, default_value = "1")]
     threads: usize,
+
+    #[clap(short = 'w', long, default_value = "2")]
+    words: usize,
 
     #[clap(long, default_value = "true")]
     print_when_found: bool,
 
-    #[clap(short, long)]
+    #[clap(short = 'p', long)]
     prefix: Option<String>,
+
+    #[clap(short = 'P', long)]
+    prefix_hash: Option<String>,
+
+    #[clap(short = 's', long)]
+    separator: Option<String>,
+
+    #[clap(short = 'x', long)]
+    suffix: Option<String>,
 }
 
 // borrow of partially moved deez. this sucks
@@ -27,23 +41,21 @@ struct Args {
 struct Settings {
     threads: usize,
     print_when_found: bool,
-    prefix: Option<String>,
+    prefix: String,
+    prefix_hash: XivCrc32,
+    separator: String,
+    separator_hash: XivCrc32,
+    suffix: String,
+    suffix_hash: XivCrc32,
+    max_words: usize,
     words: Vec<String>,
 }
 
 #[derive(Clone)]
 struct WordTable {
-    all_str_to_crc: HashMap<String, u32>,
-    our_str_to_crc: HashMap<String, u32>,
-    max_word_len: usize,
-}
-
-fn xiv_crc32(s: &[u8]) -> u32 {
-    unsafe { !(crc32(0xFFFFFFFF, s.as_ptr(), s.len() as u32) as u32) }
-}
-
-fn xiv_crc32_combine(a: u32, b: u32, b_len: usize) -> u32 {
-    unsafe { crc32_combine(a as u64, b as u64, b_len as isize) as u32 }
+    bare_str_to_crc: Vec<HashMap<String, u32>>,
+    suffixed_crc_to_str: Vec<HashMap<u32, String>>,
+    prefixed_str_to_crc: HashMap<String, XivCrc32>,
 }
 
 fn bruteforce(
@@ -52,95 +64,137 @@ fn bruteforce(
     settings: Settings,
     tx: std::sync::mpsc::Sender<Option<String>>,
 ) {
-    for (word_one, hash_one) in &word_table.our_str_to_crc {
-        let mut lookup: HashMap<usize, u32> = HashMap::new();
+    for (word_one, hash_one) in &word_table.prefixed_str_to_crc {
+        if (*hash_one + settings.suffix_hash).crc == target_hash {
+            let msg = format!("{}{}{}", settings.prefix, word_one, settings.suffix);
 
-        for len in 1..=word_table.max_word_len {
-            let blank_hash = xiv_crc32_combine(*hash_one, 0, len);
-            lookup.insert(len, blank_hash);
+            if settings.print_when_found {
+                println!("[match] {:x} = {}", target_hash, msg);
+            }
+
+            tx.send(Some(msg)).unwrap();
         }
 
-        for (word_two, hash_two) in &word_table.all_str_to_crc {
-            let blank_hash = lookup.get(&word_two.len()).unwrap();
-            let combined_hash = blank_hash ^ hash_two;
+        if settings.max_words == 2 {
+            let mut blank_hash = *hash_one + settings.separator_hash;
+            for suffixed_crc_to_str in &word_table.suffixed_crc_to_str {
+                blank_hash += XivCrc32::zero(1);
+                let hash_two = blank_hash.crc ^ target_hash;
+                if let Some(word_two) = suffixed_crc_to_str.get(&hash_two) {
+                    let msg = format!("{}{}{}{}{}", settings.prefix, word_one, settings.separator, word_two, settings.suffix);
 
-            if combined_hash == target_hash {
-                let msg = format!("{}{}", word_one, word_two);
+                    if settings.print_when_found {
+                        println!("[match] {:x} = {}", target_hash, msg);
+                    }
 
-                if settings.print_when_found {
-                    println!("[match] {:x} = {}", target_hash, msg);
+                    tx.send(Some(msg)).unwrap();
                 }
+            }
+        } else if settings.max_words >= 3 {
+            let mut blank_hash = *hash_one;
+            for bare_str_to_crc in &word_table.bare_str_to_crc {
+                blank_hash += XivCrc32::zero(1);
+                for (word_two, hash_two) in bare_str_to_crc {
+                    let combined_hash = blank_hash ^ XivCrc32::new(*hash_two, 0);
+                    if (combined_hash + settings.suffix_hash).crc == target_hash {
+                        let msg = format!("{}{}{}{}{}", settings.prefix, word_one, settings.separator, word_two, settings.suffix);
 
-                tx.send(Some(msg)).ok();
+                        if settings.print_when_found {
+                            println!("[match] {:x} = {}", target_hash, msg);
+                        }
+
+                        tx.send(Some(msg)).unwrap();
+                    }
+
+                    let mut blank_hash_two = combined_hash + settings.separator_hash;
+                    for suffixed_crc_to_str in &word_table.suffixed_crc_to_str {
+                        blank_hash_two += XivCrc32::zero(1);
+                        let hash_three = blank_hash_two.crc ^ target_hash;
+                        if let Some(word_three) = suffixed_crc_to_str.get(&hash_three) {
+                            let msg = format!("{}{}{}{}{}{}{}", settings.prefix, word_one, settings.separator, word_two, settings.separator, word_three, settings.suffix);
+
+                            if settings.print_when_found {
+                                println!("[match] {:x} = {}", target_hash, msg);
+                            }
+
+                            tx.send(Some(msg)).unwrap();
+                        }
+                    }
+                }
             }
         }
     }
 
-    tx.send(None).ok();
+    tx.send(None).unwrap();
 }
 
 fn bruteforce_threaded(target_hash: u32, settings: Settings) -> Vec<String> {
     let mut handles = vec![];
-    let mut mpsc_rx = vec![];
+    let (tx, rx) = std::sync::mpsc::channel();
 
-    let mut cycles = 0;
-
-    let str_to_crc: HashMap<String, u32> = settings
+    let all_str_to_crc: HashMap<String, XivCrc32> = settings
         .words
         .iter()
-        .map(|s| (s.clone(), xiv_crc32(s.as_bytes())))
+        .map(|s| (s.clone(), XivCrc32::from(&s[..])))
         .collect();
     let words_split = settings
         .words
         .chunks_exact(settings.words.len() / settings.threads)
         .collect::<Vec<_>>();
 
-    let prefix = settings.prefix.clone().unwrap_or_default();
-    let max_word_len = settings.words.iter().map(|s| s.len()).max().unwrap();
+    let (bare_str_to_crc, suffixed_crc_to_str) = {
+        let mut bare_str_to_crc_builder: Vec<HashMap<String, u32>> = Vec::new();
+        let mut suffixed_crc_to_str_builder: Vec<HashMap<u32, String>> = Vec::new();
+        for (word, hash) in &all_str_to_crc {
+            while bare_str_to_crc_builder.len() < word.len() {
+                bare_str_to_crc_builder.push(HashMap::new());
+            }
+            while suffixed_crc_to_str_builder.len() < word.len() + settings.suffix_hash.len {
+                suffixed_crc_to_str_builder.push(HashMap::new());
+            }
+            bare_str_to_crc_builder[word.len() - 1].insert(word.to_owned(), hash.crc);
+            if let Some(other_word) = suffixed_crc_to_str_builder[word.len() + settings.suffix_hash.len - 1].insert((*hash + settings.suffix_hash).crc, word.to_owned()) {
+                println!("Collision between words {} and {}", other_word, word);
+            }
+        }
+        (bare_str_to_crc_builder, suffixed_crc_to_str_builder)
+    };
 
     (0..settings.threads).for_each(|i| {
-        let our_words = words_split[i]
+        let our_words = Vec::from(words_split[i]);
+        let our_prefixed_str_to_crc: HashMap<String, XivCrc32> = our_words
             .iter()
-            .map(|s| format!("{}{}", prefix, s))
-            .collect::<Vec<String>>();
-        let our_str_to_crc: HashMap<String, u32> = our_words
-            .iter()
-            .map(|s| (s.clone(), xiv_crc32(s.as_bytes())))
+            .map(|s| (s.clone(), settings.prefix_hash + XivCrc32::from(&s[..])))
             .collect();
 
-        cycles += our_words.len() * settings.words.len();
-
-        let (tx, rx) = std::sync::mpsc::channel();
+        let worker_tx = tx.clone();
 
         // .clone() makes me sad
         let settings = settings.clone();
         let word_table = WordTable {
-            all_str_to_crc: str_to_crc.clone(),
-            our_str_to_crc,
-            max_word_len,
+            bare_str_to_crc: bare_str_to_crc.clone(),
+            suffixed_crc_to_str: suffixed_crc_to_str.clone(),
+            prefixed_str_to_crc: our_prefixed_str_to_crc,
         };
 
         let handle = std::thread::spawn(move || {
-            bruteforce(target_hash, word_table, settings, tx);
+            bruteforce(target_hash, word_table, settings, worker_tx);
         });
 
         handles.push(handle);
-        mpsc_rx.push(rx);
     });
 
     let mut ret_none = 0;
     let mut possible = vec![];
 
     loop {
-        for rx in &mpsc_rx {
-            if let Ok(result) = rx.try_recv() {
-                match result {
-                    Some(r) => {
-                        possible.push(r);
-                    }
-                    None => {
-                        ret_none += 1;
-                    }
+        if let Ok(result) = rx.recv() {
+            match result {
+                Some(r) => {
+                    possible.push(r);
+                }
+                None => {
+                    ret_none += 1;
                 }
             }
         }
@@ -153,26 +207,30 @@ fn bruteforce_threaded(target_hash: u32, settings: Settings) -> Vec<String> {
 
 fn test() {
     // found with xiv_crc32(str.as_bytes())
-    let crc_g = 0xd168b105;
-    let crc_emissivecolor = 0x900676f0;
-    let crc_g_emissivecolor = 0x38a64362;
+    let crc_g = XivCrc32::new(0xD168B105, 2);
+    let crc_emissivecolor = XivCrc32::new(0x900676F0, 13);
+    let crc_g_emissivecolor = XivCrc32::new(0x38A64362, 15);
 
-    let test_full = xiv_crc32(b"g_EmissiveColor");
+    let test_full = XivCrc32::from(b"g_EmissiveColor");
     assert_eq!(test_full, crc_g_emissivecolor);
 
-    let test_g = xiv_crc32(b"g_");
+    let test_g = XivCrc32::from(b"g_");
     assert_eq!(test_g, crc_g);
 
-    let test_emissivecolor = xiv_crc32(b"EmissiveColor");
+    let test_emissivecolor = XivCrc32::from(b"EmissiveColor");
     assert_eq!(test_emissivecolor, crc_emissivecolor);
 
-    let test_full = xiv_crc32_combine(test_g, test_emissivecolor, b"EmissiveColor".len());
+    let test_full = test_g + test_emissivecolor;
     assert_eq!(test_full, crc_g_emissivecolor);
 }
 
 fn main() {
     let args = Args::parse();
     test();
+
+    if args.words < 1 || args.words > 3 {
+        panic!("--words must be 1, 2 or 3");
+    }
 
     let wordlist = std::fs::read_to_string(args.word_list).unwrap();
     let hashes = std::fs::read_to_string(args.hash_list).unwrap();
@@ -182,18 +240,56 @@ fn main() {
     words.sort();
     words.dedup();
 
-    println!(
-        "[bruteforce] starting bruteforce - {} hashes, {} words",
-        hashes.len(),
-        words.len()
-    );
+    let (prefix, prefix_hash) = match &args.prefix {
+        Some(s) => match &args.prefix_hash {
+            Some(hs) => (format!("…{}", s), XivCrc32::new(u32::from_str_radix(hs, 16).unwrap(), 0) + XivCrc32::from(&s[..])),
+            None => (s.clone(), XivCrc32::from(&s[..])),
+        },
+        None => match &args.prefix_hash {
+            Some(hs) => ("…".to_string(), XivCrc32::new(u32::from_str_radix(hs, 16).unwrap(), 0)),
+            None => (String::new(), XivCrc32::default()),
+        },
+    };
+
+    let (separator, separator_hash) = match &args.separator {
+        Some(s) => (s.clone(), XivCrc32::from(&s[..])),
+        None => (String::new(), XivCrc32::default()),
+    };
+
+    let (suffix, suffix_hash) = match &args.suffix {
+        Some(s) => (s.clone(), XivCrc32::from(&s[..])),
+        None => (String::new(), XivCrc32::default()),
+    };
 
     let settings = Settings {
         threads: args.threads,
         print_when_found: args.print_when_found,
-        prefix: args.prefix,
+        prefix,
+        prefix_hash,
+        separator,
+        separator_hash,
+        suffix,
+        suffix_hash,
+        max_words: args.words,
         words,
     };
+
+    println!(
+        "using prefix \"{}\" ({:x}), separator \"{}\" ({:x}), suffix \"{}\" ({:x})",
+        settings.prefix,
+        settings.prefix_hash.crc,
+        settings.separator,
+        settings.separator_hash.crc,
+        settings.suffix,
+        settings.suffix_hash.crc,
+    );
+
+    println!(
+        "[bruteforce] starting bruteforce - {} hashes, {} words, {} words max",
+        hashes.len(),
+        settings.words.len(),
+        settings.max_words,
+    );
 
     for hash in hashes {
         let mut hash = hash;

--- a/src/xivcrc32.rs
+++ b/src/xivcrc32.rs
@@ -1,0 +1,81 @@
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::BitXor;
+use std::ops::BitXorAssign;
+
+fn crc32(crc: u32, s: &[u8]) -> u32 {
+    unsafe { cloudflare_zlib_sys::crc32(crc as u64, s.as_ptr(), s.len() as u32) as u32 }
+}
+
+fn crc32_combine(crc1: u32, crc2: u32, len2: usize) -> u32 {
+    unsafe { cloudflare_zlib_sys::crc32_combine(crc1 as u64, crc2 as u64, len2 as isize) as u32 }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
+pub struct XivCrc32 {
+    pub crc: u32,
+    pub len: usize,
+}
+
+impl XivCrc32 {
+    pub fn new(crc: u32, len: usize) -> Self {
+        Self {
+            crc,
+            len,
+        }
+    }
+    pub fn zero(len: usize) -> Self {
+        Self {
+            crc: 0,
+            len,
+        }
+    }
+}
+
+impl From<&[u8]> for XivCrc32 {
+    fn from(s: &[u8]) -> Self {
+        Self::new(!crc32(0xFFFFFFFF, s), s.len())
+    }
+}
+
+impl <const N: usize> From<&[u8; N]> for XivCrc32 {
+    fn from(s: &[u8; N]) -> Self {
+        Self::new(!crc32(0xFFFFFFFF, s), N)
+    }
+}
+
+impl From<&str> for XivCrc32 {
+    fn from(s: &str) -> Self {
+        Self::from(s.as_bytes())
+    }
+}
+
+impl Add<XivCrc32> for XivCrc32 {
+    type Output = XivCrc32;
+
+    fn add(self, rhs: XivCrc32) -> Self::Output {
+        Self::new(crc32_combine(self.crc, rhs.crc, rhs.len), self.len + rhs.len)
+    }
+}
+
+impl AddAssign<XivCrc32> for XivCrc32 {
+    fn add_assign(&mut self, rhs: XivCrc32) {
+        self.crc = crc32_combine(self.crc, rhs.crc, rhs.len);
+        self.len += rhs.len;
+    }
+}
+
+impl BitXor<XivCrc32> for XivCrc32 {
+    type Output = XivCrc32;
+
+    fn bitxor(self, rhs: XivCrc32) -> Self::Output {
+        Self::new(self.crc ^ rhs.crc, self.len.max(rhs.len))
+    }
+}
+
+impl BitXorAssign<XivCrc32> for XivCrc32 {
+    fn bitxor_assign(&mut self, rhs: XivCrc32) {
+        self.crc ^= rhs.crc;
+        self.len = self.len.max(rhs.len);
+    }
+}


### PR DESCRIPTION
- Use some kind of meet-in-the-middle attack to speed up things even more :comet: ;
- Try single-word "combinations" ;
- Optionally try triple-word "combinations" (have fun with collisions though) ;
- Partial cracking by passing a prefix hash ;
- Separator between words, and suffix ;
- Better use of MPSC channel ;
- Make a (CRC, length) pair its own type for reusability

Are we fast yet?